### PR TITLE
Minor interface cleanup and additional utility functions.

### DIFF
--- a/alquimia/alquimia_interface.h
+++ b/alquimia/alquimia_interface.h
@@ -88,7 +88,7 @@ extern "C" {
     /* take one (or more?) reaction steps in operator split mode */
     void (*ReactionStepOperatorSplit)(
         void* pft_engine_state,
-        double* delta_t,
+        double delta_t,
         AlquimiaProperties* props,
         AlquimiaState* state,
         AlquimiaAuxiliaryData* aux_data,

--- a/alquimia/alquimia_util.c
+++ b/alquimia/alquimia_util.c
@@ -86,36 +86,39 @@ void AlquimiaFindIndexFromName(const char* const name,
  **
  *******************************************************************************/
 void PrintAlquimiaVectorDouble(const char* const name,
-                               const AlquimiaVectorDouble* const vector) {
+                               const AlquimiaVectorDouble* const vector,
+                               FILE* file) {
   int i;
-  fprintf(stdout, "    %s (%d) (%p):\n", name, vector->size, (void*)(&vector->data));
-  fprintf(stdout, "   [ ");
+  fprintf(file, "    %s (%d) (%p):\n", name, vector->size, (void*)(&vector->data));
+  fprintf(file, "   [ ");
   for (i = 0; i < vector->size; ++i) {
-    fprintf(stdout, "%e, ", vector->data[i]);
+    fprintf(file, "%e, ", vector->data[i]);
   }
-  fprintf(stdout, "]\n");
+  fprintf(file, "]\n");
 }  /* end PrintAlqumiaVectorDouble() */
 
 void PrintAlquimiaVectorInt(const char* const name,
-                            const AlquimiaVectorInt* const vector) {
+                            const AlquimiaVectorInt* const vector,
+                            FILE* file) {
   int i;
-  fprintf(stdout, "    %s (%d) (%p):\n", name, vector->size, (void*)(&vector->data));
-  fprintf(stdout, "   [ ");
+  fprintf(file, "    %s (%d) (%p):\n", name, vector->size, (void*)(&vector->data));
+  fprintf(file, "   [ ");
   for (i = 0; i < vector->size; ++i) {
-    fprintf(stdout, "%d, ", vector->data[i]);
+    fprintf(file, "%d, ", vector->data[i]);
   }
-  fprintf(stdout, "]\n");
+  fprintf(file, "]\n");
 }  /* end PrintAlqumiaVectorInt() */
 
 void PrintAlquimiaVectorString(const char* const name,
-                               const AlquimiaVectorString* const vector) {
+                               const AlquimiaVectorString* const vector,
+                               FILE* file) {
   int i;
-  fprintf(stdout, "    %s (%d) (%p):\n", name, vector->size, (void*)(&vector->data));
-  fprintf(stdout, "   [ ");
+  fprintf(file, "    %s (%d) (%p):\n", name, vector->size, (void*)(&vector->data));
+  fprintf(file, "   [ ");
   for (i = 0; i < vector->size; ++i) {
-    fprintf(stdout, "'%s', ", vector->data[i]);
+    fprintf(file, "'%s', ", vector->data[i]);
   }
-  fprintf(stdout, "]\n");
+  fprintf(file, "]\n");
 }  /* end PrintAlqumiaVectorInt() */
 
 
@@ -124,147 +127,147 @@ void PrintAlquimiaVectorString(const char* const name,
  **  Printing Containers
  **
  *******************************************************************************/
-void PrintAlquimiaData(const AlquimiaData* const data) {
-  fprintf(stdout, "- Alquimia Data ----------------------------------------\n");
-  fprintf(stdout, "  engine_state : %p\n", data->engine_state);
-  PrintAlquimiaSizes(&data->sizes);
-  PrintAlquimiaEngineFunctionality(&data->functionality);
-  PrintAlquimiaState(&data->state);
-  PrintAlquimiaProperties(&data->properties);
-  PrintAlquimiaAuxiliaryData(&data->aux_data);
-  PrintAlquimiaProblemMetaData(&data->meta_data);
-  PrintAlquimiaAuxiliaryOutputData(&data->aux_output);
-  fprintf(stdout, "---------------------------------------- Alquimia Data -\n");
+void PrintAlquimiaData(const AlquimiaData* const data, FILE* file) {
+  fprintf(file, "- Alquimia Data ----------------------------------------\n");
+  fprintf(file, "  engine_state : %p\n", data->engine_state);
+  PrintAlquimiaSizes(&data->sizes, file);
+  PrintAlquimiaEngineFunctionality(&data->functionality, file);
+  PrintAlquimiaState(&data->state, file);
+  PrintAlquimiaProperties(&data->properties, file);
+  PrintAlquimiaAuxiliaryData(&data->aux_data, file);
+  PrintAlquimiaProblemMetaData(&data->meta_data, file);
+  PrintAlquimiaAuxiliaryOutputData(&data->aux_output, file);
+  fprintf(file, "---------------------------------------- Alquimia Data -\n");
 }  /* end PrintAlquimiaData() */
 
-void PrintAlquimiaSizes(const AlquimiaSizes* const sizes) {
-  fprintf(stdout, "-- Alquimia Sizes :\n");
-  fprintf(stdout, "     num primary species : %d\n", sizes->num_primary);
-  fprintf(stdout, "     num sorbed : %d\n", sizes->num_sorbed);
-  fprintf(stdout, "     num minerals : %d\n", sizes->num_minerals);
-  fprintf(stdout, "     num aqueous complexes : %d\n", sizes->num_aqueous_complexes);
-  fprintf(stdout, "     num aqueous kinetics : %d\n", sizes->num_aqueous_kinetics);
-  fprintf(stdout, "     num surface sites : %d\n", sizes->num_surface_sites);
-  fprintf(stdout, "     num ion exchange sites : %d\n", sizes->num_ion_exchange_sites);
-  fprintf(stdout, "     num auxiliary integers : %d\n", sizes->num_aux_integers);
-  fprintf(stdout, "     num auxiliary doubles : %d\n", sizes->num_aux_doubles);
+void PrintAlquimiaSizes(const AlquimiaSizes* const sizes, FILE* file) {
+  fprintf(file, "-- Alquimia Sizes :\n");
+  fprintf(file, "     num primary species : %d\n", sizes->num_primary);
+  fprintf(file, "     num sorbed : %d\n", sizes->num_sorbed);
+  fprintf(file, "     num minerals : %d\n", sizes->num_minerals);
+  fprintf(file, "     num aqueous complexes : %d\n", sizes->num_aqueous_complexes);
+  fprintf(file, "     num aqueous kinetics : %d\n", sizes->num_aqueous_kinetics);
+  fprintf(file, "     num surface sites : %d\n", sizes->num_surface_sites);
+  fprintf(file, "     num ion exchange sites : %d\n", sizes->num_ion_exchange_sites);
+  fprintf(file, "     num auxiliary integers : %d\n", sizes->num_aux_integers);
+  fprintf(file, "     num auxiliary doubles : %d\n", sizes->num_aux_doubles);
 }  /* end PrintAlquimiaSizes() */
 
-void PrintAlquimiaEngineFunctionality(const AlquimiaEngineFunctionality* const functionality) {
+void PrintAlquimiaEngineFunctionality(const AlquimiaEngineFunctionality* const functionality, FILE* file) {
 
-  fprintf(stdout, "-- Alquimia Engine Functionality :\n");
-  fprintf(stdout, "     thread_safe : %d\n", functionality->thread_safe);
-  fprintf(stdout, "     temperature_dependent : %d\n",
+  fprintf(file, "-- Alquimia Engine Functionality :\n");
+  fprintf(file, "     thread_safe : %d\n", functionality->thread_safe);
+  fprintf(file, "     temperature_dependent : %d\n",
           functionality->temperature_dependent);
-  fprintf(stdout, "     pressure_dependent : %d\n", 
+  fprintf(file, "     pressure_dependent : %d\n", 
           functionality->pressure_dependent);
-  fprintf(stdout, "     porosity_update  : %d\n", functionality->porosity_update);
-  fprintf(stdout, "     index base : %d\n", functionality->index_base);
+  fprintf(file, "     porosity_update  : %d\n", functionality->porosity_update);
+  fprintf(file, "     index base : %d\n", functionality->index_base);
 }  /* end PrintAlquimiaEngineFunctionality() */
 
-void PrintAlquimiaProblemMetaData(const AlquimiaProblemMetaData* const meta_data) {
+void PrintAlquimiaProblemMetaData(const AlquimiaProblemMetaData* const meta_data, FILE* file) {
 
-  fprintf(stdout, "-- Alquimia Problem Meta Data :\n");
-  PrintAlquimiaVectorString("primary names", &(meta_data->primary_names));
-  PrintAlquimiaVectorInt("positivity names", &(meta_data->positivity));
-  PrintAlquimiaVectorString("mineral names", &(meta_data->mineral_names));
-  PrintAlquimiaVectorString("surface site names", &(meta_data->surface_site_names));
-  PrintAlquimiaVectorString("ion exchange names", &(meta_data->ion_exchange_names));
-  PrintAlquimiaVectorString("isotherm species names", &(meta_data->isotherm_species_names));
-  PrintAlquimiaVectorString("aqueous kinetic names", &(meta_data->aqueous_kinetic_names));
+  fprintf(file, "-- Alquimia Problem Meta Data :\n");
+  PrintAlquimiaVectorString("primary names", &(meta_data->primary_names), file);
+  PrintAlquimiaVectorInt("positivity names", &(meta_data->positivity), file);
+  PrintAlquimiaVectorString("mineral names", &(meta_data->mineral_names), file);
+  PrintAlquimiaVectorString("surface site names", &(meta_data->surface_site_names), file);
+  PrintAlquimiaVectorString("ion exchange names", &(meta_data->ion_exchange_names), file);
+  PrintAlquimiaVectorString("isotherm species names", &(meta_data->isotherm_species_names), file);
+  PrintAlquimiaVectorString("aqueous kinetic names", &(meta_data->aqueous_kinetic_names), file);
 }  /* end PrintAlquimiaProblemMetaData() */
 
-void PrintAlquimiaProperties(const AlquimiaProperties* const mat_prop) {
+void PrintAlquimiaProperties(const AlquimiaProperties* const mat_prop, FILE* file) {
 
-  fprintf(stdout, "-- Alquimia Properties :\n");
-  fprintf(stdout, "     volume : %f\n", mat_prop->volume);
-  fprintf(stdout, "     saturation : %f\n", mat_prop->saturation);
-  PrintAlquimiaVectorDouble("isotherm kd", &(mat_prop->isotherm_kd));
-  PrintAlquimiaVectorDouble("freundlich n", &(mat_prop->freundlich_n));
-  PrintAlquimiaVectorDouble("langmuir b", &(mat_prop->langmuir_b));
-  PrintAlquimiaVectorDouble("mineral rate cnst", &(mat_prop->mineral_rate_cnst));
-  PrintAlquimiaVectorDouble("aqueous kinetic rate cnst", &(mat_prop->aqueous_kinetic_rate_cnst));
+  fprintf(file, "-- Alquimia Properties :\n");
+  fprintf(file, "     volume : %f\n", mat_prop->volume);
+  fprintf(file, "     saturation : %f\n", mat_prop->saturation);
+  PrintAlquimiaVectorDouble("isotherm kd", &(mat_prop->isotherm_kd), file);
+  PrintAlquimiaVectorDouble("freundlich n", &(mat_prop->freundlich_n), file);
+  PrintAlquimiaVectorDouble("langmuir b", &(mat_prop->langmuir_b), file);
+  PrintAlquimiaVectorDouble("mineral rate cnst", &(mat_prop->mineral_rate_cnst), file);
+  PrintAlquimiaVectorDouble("aqueous kinetic rate cnst", &(mat_prop->aqueous_kinetic_rate_cnst), file);
 }  /* end PrintAlquimiaProperties() */
 
-void PrintAlquimiaState(const AlquimiaState* const state) {
+void PrintAlquimiaState(const AlquimiaState* const state, FILE* file) {
 
-  fprintf(stdout, "-- Alquimia State:\n");
-  fprintf(stdout, "     water density : %f\n", state->water_density);
-  fprintf(stdout, "     porosity : %f\n", state->porosity);
-  fprintf(stdout, "     temperature : %f\n", state->temperature);
-  fprintf(stdout, "     aqueous_pressure : %f\n", state->aqueous_pressure);
+  fprintf(file, "-- Alquimia State:\n");
+  fprintf(file, "     water density : %f\n", state->water_density);
+  fprintf(file, "     porosity : %f\n", state->porosity);
+  fprintf(file, "     temperature : %f\n", state->temperature);
+  fprintf(file, "     aqueous_pressure : %f\n", state->aqueous_pressure);
 
-  PrintAlquimiaVectorDouble("total_mobile", &(state->total_mobile));
-  PrintAlquimiaVectorDouble("total_immobile", &(state->total_immobile));
+  PrintAlquimiaVectorDouble("total_mobile", &(state->total_mobile), file);
+  PrintAlquimiaVectorDouble("total_immobile", &(state->total_immobile), file);
   PrintAlquimiaVectorDouble("kinetic minerals volume fraction",
-                            &(state->mineral_volume_fraction));
+                            &(state->mineral_volume_fraction), file);
   PrintAlquimiaVectorDouble("kinetic minerals specific surface area",
-                            &(state->mineral_specific_surface_area));
+                            &(state->mineral_specific_surface_area), file);
   PrintAlquimiaVectorDouble("cation_exchange_capacity",
-                            &(state->cation_exchange_capacity));
+                            &(state->cation_exchange_capacity), file);
   PrintAlquimiaVectorDouble("surface_site_density",
-                            &(state->surface_site_density));
+                            &(state->surface_site_density), file);
 }  /* end PrintAlquimiaState() */
 
-void PrintAlquimiaAuxiliaryData(const AlquimiaAuxiliaryData* const aux_data) {
+void PrintAlquimiaAuxiliaryData(const AlquimiaAuxiliaryData* const aux_data, FILE* file) {
 
-  fprintf(stdout, "-- Alquimia Auxiliary Data:\n");
-  PrintAlquimiaVectorInt("auxiliary integers", &(aux_data->aux_ints));
-  PrintAlquimiaVectorDouble("auxiliary doubles", &(aux_data->aux_doubles));
+  fprintf(file, "-- Alquimia Auxiliary Data:\n");
+  PrintAlquimiaVectorInt("auxiliary integers", &(aux_data->aux_ints), file);
+  PrintAlquimiaVectorDouble("auxiliary doubles", &(aux_data->aux_doubles), file);
 }  /* end PrintAlquimiaAuxiliaryData() */
 
-void PrintAlquimiaAuxiliaryOutputData(const AlquimiaAuxiliaryOutputData* const aux_output) {
+void PrintAlquimiaAuxiliaryOutputData(const AlquimiaAuxiliaryOutputData* const aux_output, FILE* file) {
 
-  fprintf(stdout, "-- Alquimia Auxiliary Output Data:\n");
-  fprintf(stdout, "     pH : %f\n", aux_output->pH);
+  fprintf(file, "-- Alquimia Auxiliary Output Data:\n");
+  fprintf(file, "     pH : %f\n", aux_output->pH);
 
   PrintAlquimiaVectorDouble("mineral saturation index",
-                            &(aux_output->mineral_saturation_index));
+                            &(aux_output->mineral_saturation_index), file);
   PrintAlquimiaVectorDouble("mineral reaction rate",
-                            &(aux_output->mineral_reaction_rate));
+                            &(aux_output->mineral_reaction_rate), file);
   PrintAlquimiaVectorDouble("primary free ion concentrations",
-                            &(aux_output->primary_free_ion_concentration));
+                            &(aux_output->primary_free_ion_concentration), file);
   PrintAlquimiaVectorDouble("primary activity coeff",
-                            &(aux_output->primary_activity_coeff));
+                            &(aux_output->primary_activity_coeff), file);
   PrintAlquimiaVectorDouble("secondary free ion concentrations",
-                            &(aux_output->secondary_free_ion_concentration));
+                            &(aux_output->secondary_free_ion_concentration), file);
   PrintAlquimiaVectorDouble("secondary activity coeff",
-                            &(aux_output->secondary_activity_coeff));
+                            &(aux_output->secondary_activity_coeff), file);
 }  /* end PrintAlquimiaAuxiliaryOutputData() */
 
-void PrintAlquimiaGeochemicalConditionVector(const AlquimiaGeochemicalConditionVector* const condition_list) {
+void PrintAlquimiaGeochemicalConditionVector(const AlquimiaGeochemicalConditionVector* const condition_list, FILE* file) {
   int i;
-  fprintf(stdout, "- Alquimia Geochemical Condition List ------------------\n");
+  fprintf(file, "- Alquimia Geochemical Condition List ------------------\n");
   for (i = 0; i < condition_list->size; ++i) {
-    PrintAlquimiaGeochemicalCondition(&(condition_list->data[i]));
-    fprintf(stdout, "\n");
+    PrintAlquimiaGeochemicalCondition(&(condition_list->data[i]), file);
+    fprintf(file, "\n");
   }
-  fprintf(stdout, "------------------ Alquimia Geochemical Condition List -\n");
+  fprintf(file, "------------------ Alquimia Geochemical Condition List -\n");
 }  /*  PrintAlquimiaGeochemicalConditionVector() */
 
-void PrintAlquimiaGeochemicalCondition(const AlquimiaGeochemicalCondition* const condition) {
+void PrintAlquimiaGeochemicalCondition(const AlquimiaGeochemicalCondition* const condition, FILE* file) {
   int i;
-  fprintf(stdout, "-- Alquimia Geochemical Condition : %s\n", condition->name);
+  fprintf(file, "-- Alquimia Geochemical Condition : %s\n", condition->name);
   for (i = 0; i < condition->aqueous_constraints.size; ++i) {
-    PrintAlquimiaAqueousConstraint(&(condition->aqueous_constraints.data[i]));
+    PrintAlquimiaAqueousConstraint(&(condition->aqueous_constraints.data[i]), file);
   }
   for (i = 0; i < condition->mineral_constraints.size; ++i) {
-    PrintAlquimiaMineralConstraint(&(condition->mineral_constraints.data[i]));
+    PrintAlquimiaMineralConstraint(&(condition->mineral_constraints.data[i]), file);
   }
-  fprintf(stdout, "\n");
+  fprintf(file, "\n");
 }  /*  PrintAlquimiaGeochemicalCondition() */
 
-void PrintAlquimiaAqueousConstraint(const AlquimiaAqueousConstraint* const constraint) {
-  fprintf(stdout, "--- Alquimia Aqueous Constraint : \n");
-  fprintf(stdout, "      primary species : %s\n", constraint->primary_species_name);
-  fprintf(stdout, "      constraint type : %s\n", constraint->constraint_type);
-  fprintf(stdout, "      associated species : %s\n", constraint->associated_species);
-  fprintf(stdout, "      value : %e\n", constraint->value);
+void PrintAlquimiaAqueousConstraint(const AlquimiaAqueousConstraint* const constraint, FILE* file) {
+  fprintf(file, "--- Alquimia Aqueous Constraint : \n");
+  fprintf(file, "      primary species : %s\n", constraint->primary_species_name);
+  fprintf(file, "      constraint type : %s\n", constraint->constraint_type);
+  fprintf(file, "      associated species : %s\n", constraint->associated_species);
+  fprintf(file, "      value : %e\n", constraint->value);
 }  /*  PrintAlquimiaAqueousConstraint() */
 
-void PrintAlquimiaMineralConstraint(const AlquimiaMineralConstraint* const constraint) {
-  fprintf(stdout, "--- Alquimia Mineral Constraint : \n");
-  fprintf(stdout, "      mineral : %s\n", constraint->mineral_name);
-  fprintf(stdout, "      volume fraction : %e\n", constraint->volume_fraction);
-  fprintf(stdout, "      specific surface area : %e\n", constraint->specific_surface_area);
+void PrintAlquimiaMineralConstraint(const AlquimiaMineralConstraint* const constraint, FILE* file) {
+  fprintf(file, "--- Alquimia Mineral Constraint : \n");
+  fprintf(file, "      mineral : %s\n", constraint->mineral_name);
+  fprintf(file, "      volume fraction : %e\n", constraint->volume_fraction);
+  fprintf(file, "      specific surface area : %e\n", constraint->specific_surface_area);
 }  /*  PrintAlquimiaMineralConstraint() */

--- a/alquimia/alquimia_util.c
+++ b/alquimia/alquimia_util.c
@@ -28,22 +28,22 @@
 */
 
 
-/*******************************************************************************
- **
- **  C utilities for working with alquimia data structures
- **
- *******************************************************************************/
+//------------------------------------------------------------------------
+//
+//   C utilities for working with alquimia data structures
+//
+//------------------------------------------------------------------------
 
 #include "alquimia/alquimia_util.h"
 #include "alquimia/alquimia_containers.h"
 #include "alquimia/alquimia_interface.h"
 #include "alquimia/alquimia_constants.h"
 
-/*******************************************************************************
- **
- **  Strings
- **
- *******************************************************************************/
+//------------------------------------------------------------------------
+//
+//   Strings
+//
+//------------------------------------------------------------------------
 bool AlquimiaCaseInsensitiveStringCompare(const char* const str1,
                                           const char* const str2) {
   int i;
@@ -61,11 +61,11 @@ bool AlquimiaCaseInsensitiveStringCompare(const char* const str1,
   return equal;
 }  /* end AlquimiaCaseInsensitiveStringCompare() */
 
-/*******************************************************************************
- **
- **  Mapping Species names - and indices
- **
- *******************************************************************************/
+//------------------------------------------------------------------------
+//
+//   Mapping Species names - and indices
+//
+//------------------------------------------------------------------------
 void AlquimiaFindIndexFromName(const char* const name,
                                const AlquimiaVectorString* const names,
                                int* index) {
@@ -80,11 +80,192 @@ void AlquimiaFindIndexFromName(const char* const name,
 }  /* end AlquimiaFindIndexFromName() */
 
 
-/*******************************************************************************
- **
- **  Printing Vectors
- **
- *******************************************************************************/
+//------------------------------------------------------------------------
+//
+//   Copying containers
+//
+//------------------------------------------------------------------------
+void CopyAlquimiaVectorDouble(const AlquimiaVectorDouble* const source,
+                              AlquimiaVectorDouble* destination)
+{
+  if (destination->size != source->size)
+  {
+    destination->size = source->size;
+    destination->data = realloc(destination->data, sizeof(double) * destination->size);
+  }
+  memcpy(destination->data, source->data, sizeof(double) * destination->size);
+}
+
+void CopyAlquimiaVectorInt(const AlquimiaVectorInt* const source,
+                           AlquimiaVectorInt* destination)
+{
+  if (destination->size != source->size)
+  {
+    destination->size = source->size;
+    destination->data = realloc(destination->data, sizeof(int) * destination->size);
+  }
+  memcpy(destination->data, source->data, sizeof(int) * destination->size);
+}
+
+void CopyAlquimiaVectorString(const AlquimiaVectorString* const source,
+                              AlquimiaVectorString* destination)
+{
+  if (destination->size != source->size)
+  {
+    destination->size = source->size;
+    destination->data = realloc(destination->data, sizeof(char*) * destination->size);
+  }
+  for (int i = 0; i < destination->size; ++i)
+    destination->data[i] = strdup(source->data[i]);
+}
+
+void CopyAlquimiaSizes(const AlquimiaSizes* const source, 
+                       AlquimiaSizes* destination)
+{
+  memcpy(destination, source, sizeof(AlquimiaSizes));
+}
+
+void CopyAlquimiaProblemMetaData(const AlquimiaProblemMetaData* const source, 
+                                 AlquimiaProblemMetaData* destination)
+{
+  CopyAlquimiaVectorString(&source->primary_names, &destination->primary_names);
+  CopyAlquimiaVectorInt(&source->positivity, &destination->positivity);
+  CopyAlquimiaVectorString(&source->mineral_names, &destination->mineral_names);
+  CopyAlquimiaVectorString(&source->surface_site_names, &destination->surface_site_names);
+  CopyAlquimiaVectorString(&source->ion_exchange_names, &destination->ion_exchange_names);
+  CopyAlquimiaVectorString(&source->isotherm_species_names, &destination->isotherm_species_names);
+  CopyAlquimiaVectorString(&source->aqueous_kinetic_names, &destination->aqueous_kinetic_names);
+}
+
+void CopyAlquimiaProperties(const AlquimiaProperties* const source, 
+                            AlquimiaProperties* destination)
+{
+  destination->volume = source->volume;
+  destination->saturation = source->saturation;
+  CopyAlquimiaVectorDouble(&source->isotherm_kd, &destination->isotherm_kd);
+  CopyAlquimiaVectorDouble(&source->freundlich_n, &destination->freundlich_n);
+  CopyAlquimiaVectorDouble(&source->langmuir_b, &destination->langmuir_b);
+  CopyAlquimiaVectorDouble(&source->mineral_rate_cnst, &destination->mineral_rate_cnst);
+  CopyAlquimiaVectorDouble(&source->aqueous_kinetic_rate_cnst, &destination->aqueous_kinetic_rate_cnst);
+}
+
+void CopyAlquimiaEngineFunctionality(const AlquimiaEngineFunctionality* const source, 
+                                     AlquimiaEngineFunctionality* destination)
+{
+  memcpy(destination, source, sizeof(AlquimiaEngineFunctionality));
+}
+
+void CopyAlquimiaState(const AlquimiaState* const source, 
+                       AlquimiaState* destination)
+{
+  destination->water_density = source->water_density;
+  destination->porosity = source->porosity;
+  destination->temperature = source->temperature;
+  destination->aqueous_pressure = source->aqueous_pressure;
+  CopyAlquimiaVectorDouble(&source->total_mobile, &destination->total_mobile);
+  CopyAlquimiaVectorDouble(&source->total_immobile, &destination->total_immobile);
+  CopyAlquimiaVectorDouble(&source->mineral_volume_fraction, &destination->mineral_volume_fraction);
+  CopyAlquimiaVectorDouble(&source->mineral_specific_surface_area, &destination->mineral_specific_surface_area);
+  CopyAlquimiaVectorDouble(&source->surface_site_density, &destination->surface_site_density);
+  CopyAlquimiaVectorDouble(&source->cation_exchange_capacity, &destination->cation_exchange_capacity);
+}
+
+void CopyAlquimiaAuxiliaryData(const AlquimiaAuxiliaryData* const source, 
+                               AlquimiaAuxiliaryData* destination)
+{
+  CopyAlquimiaVectorInt(&source->aux_ints, &destination->aux_ints);
+  CopyAlquimiaVectorDouble(&source->aux_doubles, &destination->aux_doubles);
+}
+
+void CopyAlquimiaAuxiliaryOutputData(const AlquimiaAuxiliaryOutputData* const source, 
+                                     AlquimiaAuxiliaryOutputData* destination)
+{
+  destination->pH = source->pH;
+  CopyAlquimiaVectorDouble(&source->aqueous_kinetic_rate, &destination->aqueous_kinetic_rate);
+  CopyAlquimiaVectorDouble(&source->mineral_saturation_index, &destination->mineral_saturation_index);
+  CopyAlquimiaVectorDouble(&source->mineral_reaction_rate, &destination->mineral_reaction_rate);
+  CopyAlquimiaVectorDouble(&source->primary_free_ion_concentration, &destination->primary_free_ion_concentration);
+  CopyAlquimiaVectorDouble(&source->primary_activity_coeff, &destination->primary_activity_coeff);
+  CopyAlquimiaVectorDouble(&source->secondary_free_ion_concentration, &destination->secondary_free_ion_concentration);
+  CopyAlquimiaVectorDouble(&source->secondary_activity_coeff, &destination->secondary_activity_coeff);
+}
+
+void CopyAlquimiaGeochemicalCondition(const AlquimiaGeochemicalCondition* const source, 
+                                      AlquimiaGeochemicalCondition* destination)
+{
+  if (destination->name != NULL)
+    free(destination->name);
+  destination->name = strdup(source->name);
+  CopyAlquimiaAqueousConstraintVector(&source->aqueous_constraints, &destination->aqueous_constraints);
+  CopyAlquimiaMineralConstraintVector(&source->mineral_constraints, &destination->mineral_constraints);
+}
+
+void CopyAlquimiaGeochemicalConditionVector(const AlquimiaGeochemicalConditionVector* source, 
+                                            AlquimiaGeochemicalConditionVector* destination)
+{
+  if (destination->size != source->size)
+  {
+    destination->size = source->size;
+    destination->data = realloc(destination->data, sizeof(AlquimiaGeochemicalCondition) * destination->size);
+  }
+  for (int i = 0; i < destination->size; ++i)
+    CopyAlquimiaGeochemicalCondition(&source->data[i], &destination->data[i]);
+}
+
+void CopyAlquimiaAqueousConstraint(const AlquimiaAqueousConstraint* const source, 
+                                   AlquimiaAqueousConstraint* destination)
+{
+  if (destination->primary_species_name != NULL)
+    free(destination->primary_species_name);
+  destination->primary_species_name = strdup(source->primary_species_name);
+  if (destination->constraint_type != NULL)
+    free(destination->constraint_type);
+  destination->constraint_type = strdup(source->constraint_type);
+  if (destination->associated_species != NULL)
+    free(destination->associated_species);
+  destination->associated_species = strdup(source->associated_species);
+  destination->value = source->value;
+}
+
+void CopyAlquimiaAqueousConstraintVector(const AlquimiaAqueousConstraintVector* const source, 
+                                         AlquimiaAqueousConstraintVector* destination)
+{
+  if (destination->size != source->size)
+  {
+    destination->size = source->size;
+    destination->data = realloc(destination->data, sizeof(AlquimiaAqueousConstraint) * destination->size);
+  }
+  for (int i = 0; i < destination->size; ++i)
+    CopyAlquimiaAqueousConstraint(&source->data[i], &destination->data[i]);
+}
+
+void CopyAlquimiaMineralConstraint(const AlquimiaMineralConstraint* const source, 
+                                   AlquimiaMineralConstraint* destination)
+{
+  if (destination->mineral_name != NULL)
+    free(destination->mineral_name);
+  destination->mineral_name = strdup(source->mineral_name);
+  destination->volume_fraction = source->volume_fraction;
+  destination->specific_surface_area = source->specific_surface_area;
+}
+
+void CopyAlquimiaMineralConstraintVector(const AlquimiaMineralConstraintVector* const source, 
+                                         AlquimiaMineralConstraintVector* destination)
+{
+  if (destination->size != source->size)
+  {
+    destination->size = source->size;
+    destination->data = realloc(destination->data, sizeof(AlquimiaMineralConstraint) * destination->size);
+  }
+  for (int i = 0; i < destination->size; ++i)
+    CopyAlquimiaMineralConstraint(&source->data[i], &destination->data[i]);
+}
+
+//------------------------------------------------------------------------
+//
+//   Printing vectors
+//
+//------------------------------------------------------------------------
 void PrintAlquimiaVectorDouble(const char* const name,
                                const AlquimiaVectorDouble* const vector,
                                FILE* file) {
@@ -122,11 +303,11 @@ void PrintAlquimiaVectorString(const char* const name,
 }  /* end PrintAlqumiaVectorInt() */
 
 
-/*******************************************************************************
- **
- **  Printing Containers
- **
- *******************************************************************************/
+//------------------------------------------------------------------------
+//
+//   Printing containers
+//
+//------------------------------------------------------------------------
 void PrintAlquimiaData(const AlquimiaData* const data, FILE* file) {
   fprintf(file, "- Alquimia Data ----------------------------------------\n");
   fprintf(file, "  engine_state : %p\n", data->engine_state);

--- a/alquimia/alquimia_util.h
+++ b/alquimia/alquimia_util.h
@@ -37,6 +37,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
+  // String manipulation functions.
   bool AlquimiaCaseInsensitiveStringCompare(const char* const str1,
                                             const char* const str2);
 
@@ -44,25 +45,29 @@ extern "C" {
                                  const AlquimiaVectorString* const names,
                                    int* index);
 
+  // The following functions write data to the given FILE.
   void PrintAlquimiaVectorDouble(const char* const name,
-                                 const AlquimiaVectorDouble* const vector);
+                                 const AlquimiaVectorDouble* const vector,
+                                 FILE* file);
   void PrintAlquimiaVectorInt(const char* const name,
-                              const AlquimiaVectorInt* const vector);
+                              const AlquimiaVectorInt* const vector,
+                              FILE* file);
   void PrintAlquimiaVectorString(const char* const name,
-                                 const AlquimiaVectorString* const vector);
+                                 const AlquimiaVectorString* const vector,
+                                 FILE* file);
 
-  void PrintAlquimiaData(const AlquimiaData* const data);
-  void PrintAlquimiaSizes(const AlquimiaSizes* const sizes);
-  void PrintAlquimiaProblemMetaData(const AlquimiaProblemMetaData* const meta_data);
-  void PrintAlquimiaProperties(const AlquimiaProperties* const prop);
-  void PrintAlquimiaEngineFunctionality(const AlquimiaEngineFunctionality* const functionality);
-  void PrintAlquimiaState(const AlquimiaState* const state);
-  void PrintAlquimiaAuxiliaryData(const AlquimiaAuxiliaryData* const aux_data);
-  void PrintAlquimiaAuxiliaryOutputData(const AlquimiaAuxiliaryOutputData* const aux_output);
-  void PrintAlquimiaGeochemicalConditionVector(const AlquimiaGeochemicalConditionVector* condition_list);
-  void PrintAlquimiaGeochemicalCondition(const AlquimiaGeochemicalCondition* const condition);
-  void PrintAlquimiaAqueousConstraint(const AlquimiaAqueousConstraint* const constraint);
-  void PrintAlquimiaMineralConstraint(const AlquimiaMineralConstraint* const constraint);
+  void PrintAlquimiaData(const AlquimiaData* const data, FILE* file);
+  void PrintAlquimiaSizes(const AlquimiaSizes* const sizes, FILE* file);
+  void PrintAlquimiaProblemMetaData(const AlquimiaProblemMetaData* const meta_data, FILE* file);
+  void PrintAlquimiaProperties(const AlquimiaProperties* const prop, FILE* file);
+  void PrintAlquimiaEngineFunctionality(const AlquimiaEngineFunctionality* const functionality, FILE* file);
+  void PrintAlquimiaState(const AlquimiaState* const state, FILE* file);
+  void PrintAlquimiaAuxiliaryData(const AlquimiaAuxiliaryData* const aux_data, FILE* file);
+  void PrintAlquimiaAuxiliaryOutputData(const AlquimiaAuxiliaryOutputData* const aux_output, FILE* file);
+  void PrintAlquimiaGeochemicalConditionVector(const AlquimiaGeochemicalConditionVector* condition_list, FILE* file);
+  void PrintAlquimiaGeochemicalCondition(const AlquimiaGeochemicalCondition* const condition, FILE* file);
+  void PrintAlquimiaAqueousConstraint(const AlquimiaAqueousConstraint* const constraint, FILE* file);
+  void PrintAlquimiaMineralConstraint(const AlquimiaMineralConstraint* const constraint, FILE* file);
 
 #ifdef __cplusplus
 }

--- a/alquimia/alquimia_util.h
+++ b/alquimia/alquimia_util.h
@@ -43,7 +43,41 @@ extern "C" {
 
   void AlquimiaFindIndexFromName(const char* const name,
                                  const AlquimiaVectorString* const names,
-                                   int* index);
+                                 int* index);
+
+  // Functions for copying Alquimia containers.
+  void CopyAlquimiaVectorDouble(const AlquimiaVectorDouble* const source,
+                                AlquimiaVectorDouble* destination);
+  void CopyAlquimiaVectorInt(const AlquimiaVectorInt* const source,
+                             AlquimiaVectorInt* destination);
+  void CopyAlquimiaVectorString(const AlquimiaVectorString* const source,
+                                AlquimiaVectorString* destination);
+  void CopyAlquimiaSizes(const AlquimiaSizes* const source, 
+                         AlquimiaSizes* destination);
+  void CopyAlquimiaProblemMetaData(const AlquimiaProblemMetaData* const source, 
+                                   AlquimiaProblemMetaData* destination);
+  void CopyAlquimiaProperties(const AlquimiaProperties* const source, 
+                              AlquimiaProperties* destination);
+  void CopyAlquimiaEngineFunctionality(const AlquimiaEngineFunctionality* const source, 
+                                       AlquimiaEngineFunctionality* destination);
+  void CopyAlquimiaState(const AlquimiaState* const source, 
+                         AlquimiaState* destination);
+  void CopyAlquimiaAuxiliaryData(const AlquimiaAuxiliaryData* const source, 
+                                 AlquimiaAuxiliaryData* destination);
+  void CopyAlquimiaAuxiliaryOutputData(const AlquimiaAuxiliaryOutputData* const source, 
+                                       AlquimiaAuxiliaryOutputData* destination);
+  void CopyAlquimiaGeochemicalCondition(const AlquimiaGeochemicalCondition* const source, 
+                                        AlquimiaGeochemicalCondition* destination);
+  void CopyAlquimiaGeochemicalConditionVector(const AlquimiaGeochemicalConditionVector* source, 
+                                              AlquimiaGeochemicalConditionVector* destination);
+  void CopyAlquimiaAqueousConstraint(const AlquimiaAqueousConstraint* const source, 
+                                     AlquimiaAqueousConstraint* destination);
+  void CopyAlquimiaAqueousConstraintVector(const AlquimiaAqueousConstraintVector* const source, 
+                                           AlquimiaAqueousConstraintVector* destination);
+  void CopyAlquimiaMineralConstraint(const AlquimiaMineralConstraint* const source, 
+                                     AlquimiaMineralConstraint* destination);
+  void CopyAlquimiaMineralConstraintVector(const AlquimiaMineralConstraintVector* const source, 
+                                           AlquimiaMineralConstraintVector* destination);
 
   // The following functions write data to the given FILE.
   void PrintAlquimiaVectorDouble(const char* const name,

--- a/alquimia/crunch_alquimia_interface.F90
+++ b/alquimia/crunch_alquimia_interface.F90
@@ -610,7 +610,7 @@ subroutine ReactionStepOperatorSplit(cf_engine_state, &
 
   ! function parameters
   type (c_ptr), intent(inout) :: cf_engine_state
-  real (c_double), intent(in) :: delta_t
+  real (c_double), value, intent(in) :: delta_t
   type (AlquimiaProperties), intent(in) :: properties
   type (AlquimiaState), intent(inout) :: state
   type (AlquimiaAuxiliaryData), intent(inout) :: aux_data

--- a/alquimia/crunch_alquimia_interface.h
+++ b/alquimia/crunch_alquimia_interface.h
@@ -62,7 +62,7 @@ extern "C" {
       AlquimiaEngineStatus* status);
   void crunch_alquimia_reactionstepoperatorsplit(
       void* cf_engine_state,
-      double* delta_t,
+      double delta_t,
       AlquimiaProperties* properties,
       AlquimiaState* state,
       AlquimiaAuxiliaryData* aux_data,

--- a/alquimia/crunch_alquimia_wrappers.F90
+++ b/alquimia/crunch_alquimia_wrappers.F90
@@ -144,7 +144,7 @@ subroutine Crunch_Alquimia_ReactionStepOperatorSplit( &
 
   ! function parameters
   type (c_ptr), intent(inout) :: cf_engine_state
-  real (c_double), intent(in) :: delta_t
+  real (c_double), value, intent(in) :: delta_t
   type (AlquimiaProperties), intent(in) :: properties
   type (AlquimiaState), intent(inout) :: state
   type (AlquimiaAuxiliaryData), intent(inout) :: aux_data

--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -462,7 +462,7 @@ subroutine ReactionStepOperatorSplit(pft_engine_state, &
 
   ! function parameters
   type (c_ptr), intent(inout) :: pft_engine_state
-  real (c_double), intent(in) :: delta_t
+  real (c_double), value, intent(in) :: delta_t
   type (AlquimiaProperties), intent(in) :: properties
   type (AlquimiaState), intent(inout) :: state
   type (AlquimiaAuxiliaryData), intent(inout) :: aux_data

--- a/alquimia/pflotran_alquimia_interface.h
+++ b/alquimia/pflotran_alquimia_interface.h
@@ -62,7 +62,7 @@ extern "C" {
       AlquimiaEngineStatus* status);
   void pflotran_alquimia_reactionstepoperatorsplit(
       void* pft_engine_state,
-      double* delta_t,
+      double delta_t,
       AlquimiaProperties* material_properties,
       AlquimiaState* state,
       AlquimiaAuxiliaryData* aux_data,

--- a/alquimia/pflotran_alquimia_wrappers.F90
+++ b/alquimia/pflotran_alquimia_wrappers.F90
@@ -143,7 +143,7 @@ subroutine PFloTran_Alquimia_ReactionStepOperatorSplit( &
 
   ! function parameters
   type (c_ptr), intent(inout) :: pft_engine_state
-  real (c_double), intent(in) :: delta_t
+  real (c_double), value, intent(in) :: delta_t
   type (AlquimiaProperties), intent(in) :: properties
   type (AlquimiaState), intent(inout) :: state
   type (AlquimiaAuxiliaryData), intent(inout) :: aux_data

--- a/drivers/batch_chem.cc
+++ b/drivers/batch_chem.cc
@@ -214,7 +214,7 @@ int BatchChemWithAlquimia(
              &chem_status);
   if (chem_status.error != 0) {
     std::cout << chem_status.message << std::endl;
-    PrintAlquimiaSizes(&chem_data.sizes);
+    PrintAlquimiaSizes(&chem_data.sizes, stdout);
     return chem_status.error;
   }
 
@@ -235,10 +235,10 @@ int BatchChemWithAlquimia(
                           &chem_status);
   if (chem_status.error != 0) {
     std::cout << chem_status.message << std::endl;
-    PrintAlquimiaProblemMetaData(&chem_data.meta_data);
+    PrintAlquimiaProblemMetaData(&chem_data.meta_data, stdout);
     return chem_status.error;
   }
-  //PrintAlquimiaProblemMetaData(&chem_data.meta_data);
+  //PrintAlquimiaProblemMetaData(&chem_data.meta_data, stdout);
 
   // finish initializing the driver, e.g. verify material
   // properties, species names, etc
@@ -250,7 +250,7 @@ int BatchChemWithAlquimia(
   CopyDemoPropertiesToAlquimiaMaterials(
       demo_props, chem_data.meta_data, &chem_data.properties);
 
-  PrintAlquimiaData(&chem_data);
+  PrintAlquimiaData(&chem_data, stdout);
 
   //
   // prepare for constraint processing
@@ -260,7 +260,7 @@ int BatchChemWithAlquimia(
   // and store them in alquimia's format
   CopyDemoConditionsToAlquimiaConditions(demo_conditions, &alquimia_conditions);
 
-  PrintAlquimiaGeochemicalConditionVector(&alquimia_conditions);
+  PrintAlquimiaGeochemicalConditionVector(&alquimia_conditions, stdout);
 
   for (int i = 0; i < alquimia_conditions.size; ++i) {
     // ask the engine to process the geochemical conditions
@@ -276,8 +276,8 @@ int BatchChemWithAlquimia(
                             &chem_data.aux_data,
                             &chem_status);
       if (chem_status.error != 0) {
-        PrintAlquimiaData(&chem_data);
-        PrintAlquimiaGeochemicalCondition(&(alquimia_conditions.data[i]));
+        PrintAlquimiaData(&chem_data, stdout);
+        PrintAlquimiaGeochemicalCondition(&(alquimia_conditions.data[i]), stdout);
         std::cout << chem_status.message << std::endl;
         return chem_status.error;
       }
@@ -311,8 +311,8 @@ int BatchChemWithAlquimia(
     time += delta_t;
     //std::cout << "reaction step : " << t << "  time: " << time << std::endl;
     if (false) {
-      PrintAlquimiaState(&chem_data.state);
-      PrintAlquimiaAuxiliaryData(&chem_data.aux_data);
+      PrintAlquimiaState(&chem_data.state, stdout);
+      PrintAlquimiaAuxiliaryData(&chem_data.aux_data, stdout);
     }
     // unpack from driver memory, since this is batch, no unpacking
     chem.ReactionStepOperatorSplit(&chem_data.engine_state,
@@ -323,8 +323,8 @@ int BatchChemWithAlquimia(
                                    &chem_status);
     if (chem_status.error != 0) {
       std::cout << chem_status.message << std::endl;
-      PrintAlquimiaState(&chem_data.state);
-      PrintAlquimiaAuxiliaryData(&chem_data.aux_data);
+      PrintAlquimiaState(&chem_data.state, stdout);
+      PrintAlquimiaAuxiliaryData(&chem_data.aux_data, stdout);
       return chem_status.error;
     }
     chem.GetAuxiliaryOutput(&chem_data.engine_state,

--- a/drivers/batch_chem.cc
+++ b/drivers/batch_chem.cc
@@ -316,7 +316,7 @@ int BatchChemWithAlquimia(
     }
     // unpack from driver memory, since this is batch, no unpacking
     chem.ReactionStepOperatorSplit(&chem_data.engine_state,
-                                   &delta_t,
+                                   delta_t,
                                    &chem_data.properties,
                                    &chem_data.state,
                                    &chem_data.aux_data,


### PR DESCRIPTION
* Timestep argument to operator split reaction function is now a value, not a pointer.
* PrintAlquimia* utility functions now take a FILE object as an argument instead of just printing to stdout.
* Added CopyAlquimia* utility functions for copying vectors and containers.