### PR TITLE
Ensuring that Alquimia library is always built as a static library.

### DIFF
--- a/alquimia/CMakeLists.txt
+++ b/alquimia/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 include_directories(${ALQUIMIA_INCLUDE_DIRS})
 link_libraries(${ALQUIMIA_TPLS})
-add_library(alquimia ${ALQUIMIA_SOURCES})
+add_library(alquimia STATIC ${ALQUIMIA_SOURCES})
 
 # Stuff for provenance.
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
Added STATIC keyword to CMake command that builds the Alquimia library. Building a dynamic version of this library produces issues with chemistry engines at the moment.