### PR TITLE
Changed use of !PETSC_VERSION_RELEASE to +#if PETSC_VERSION_GE(3,7,0)…

### DIFF
--- a/alquimia/pflotran_petsc_stubs.F90
+++ b/alquimia/pflotran_petsc_stubs.F90
@@ -28,7 +28,7 @@
 
 #include "petscversion.h"
 
-#if !PETSC_VERSION_RELEASE
+#if PETSC_VERSION_GE(3,7,0)
 
 subroutine petsclogbegin()
 end subroutine

--- a/drivers/batch_chem.cc
+++ b/drivers/batch_chem.cc
@@ -377,13 +377,13 @@ int CommandLineOptions(char const * const prog_name,
   PetscBool value_set = PETSC_FALSE;
   char temp_str[kAlquimiaMaxStringLength];
 
-#if !PETSC_VERSION_RELEASE
+#if PETSC_VERSION_GE(3,7,0)
   PetscOptionsHasName(NULL,NULL, "-d", debug_batch_driver);
 #else
   PetscOptionsHasName(NULL, "-d", debug_batch_driver);
 #endif
 
-#if !PETSC_VERSION_RELEASE
+#if PETSC_VERSION_GE(3,7,0)
   PetscOptionsGetString(NULL,NULL, "-i", temp_str, kAlquimiaMaxStringLength, &value_set);
 #else
   PetscOptionsGetString(NULL, "-i", temp_str, kAlquimiaMaxStringLength, &value_set);
@@ -391,7 +391,7 @@ int CommandLineOptions(char const * const prog_name,
   input_file_name->assign(temp_str);
   PetscStrncpy(temp_str, "", kAlquimiaMaxStringLength);
 
-#if !PETSC_VERSION_RELEASE
+#if PETSC_VERSION_GE(3,7,0)
   PetscOptionsGetString(NULL,NULL, "-t", temp_str, kAlquimiaMaxStringLength, &value_set);
 #else
   PetscOptionsGetString(NULL, "-t", temp_str, kAlquimiaMaxStringLength, &value_set);


### PR DESCRIPTION
… so that macro will work correctly after releases

Funded-by: IDEAS
Project: xSDK
Time: 0 hours