### PR TITLE
copying properties from alquimia in ReactionStepOperatorSplit

### DIFF
--- a/alquimia/crunch_alquimia_interface.F90
+++ b/alquimia/crunch_alquimia_interface.F90
@@ -659,7 +659,7 @@ subroutine ReactionStepOperatorSplit(cf_engine_state, &
   real(dp) :: porosity, volume, vol_frac_prim    
   integer(i4b) :: jx, jy, jz
   integer(i4b) :: i, is, ix, ik
-  logical, parameter :: copy_auxdata = .true.
+  logical, parameter :: copy_auxdata = .false. !.true.
 
   ! crunchflow local
   integer(i4b)                :: newtmax

--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -479,7 +479,7 @@ subroutine ReactionStepOperatorSplit(pft_engine_state, &
   PetscReal :: tran_xx(state%total_mobile%size)
   PetscInt :: i, num_newton_iterations
   PetscInt, parameter :: phase_index = 1
-  logical, parameter :: copy_auxdata = .true.
+  logical, parameter :: copy_auxdata = .false. !.true.
 
   call c_f_pointer(pft_engine_state, engine_state)
   if (engine_state%integrity_check /= integrity_check_value) then


### PR DESCRIPTION
Properties are typically uniform in the geochemical engines. In other words, they're not mesh-based variables. Alquimia - as a single cell model- allowed for non-uniform properties in appearance. However, these were not copied every time ReactionStepOperatorSplit was called and the mesh-based data controlled by the driver were lost. This minor change allows for non-uniform properties.