### PR TITLE
fixes clang errors/warnings generated with -Wall or -Werror,strict-prototypes

### DIFF
--- a/drivers/DriverOutput.c
+++ b/drivers/DriverOutput.c
@@ -63,7 +63,7 @@ static void GnuplotWrite(AlquimiaVectorString var_names,
   fprintf(file, "\n");
 }
 
-DriverOutput* GnuplotDriverOutput_New()
+DriverOutput* GnuplotDriverOutput_New(void)
 {
   return DriverOutput_New(GnuplotWrite);
 }
@@ -87,7 +87,7 @@ static void PythonWrite(AlquimiaVectorString var_names,
   }
 }
 
-DriverOutput* PythonDriverOutput_New()
+DriverOutput* PythonDriverOutput_New(void)
 {
   return DriverOutput_New(PythonWrite);
 }

--- a/drivers/DriverOutput.h
+++ b/drivers/DriverOutput.h
@@ -35,11 +35,11 @@
 typedef struct DriverOutput DriverOutput;
 
 // Creates a DriverOutput object that writes columnated data sensible to Gnuplot.
-DriverOutput* GnuplotDriverOutput_New();
+DriverOutput* GnuplotDriverOutput_New(void);
 
 // Creates a DriverOutput object that writes a Python module that can be imported
 // by an analysis script.
-DriverOutput* PythonDriverOutput_New();
+DriverOutput* PythonDriverOutput_New(void);
 
 // Writes the given vector(s) to the file with the given name.
 void DriverOutput_WriteVectors(DriverOutput* output, 

--- a/drivers/batch_chem.c
+++ b/drivers/batch_chem.c
@@ -31,7 +31,7 @@
 #include "BatchChemDriver.h"
 #include "DriverOutput.h"
 
-void Usage()
+void Usage(void)
 {
   printf("batch_chem: usage:\n");
   printf("batch_chem <input_file>\n\n");

--- a/drivers/transport.c
+++ b/drivers/transport.c
@@ -31,7 +31,7 @@
 #include "TransportDriver.h"
 #include "DriverOutput.h"
 
-void Usage()
+void Usage(void)
 {
   printf("transport: usage:\n");
   printf("transport <input_file>\n\n");


### PR DESCRIPTION
I get the below error when trying to build Alquimia on Ventura with newest XCode:

```
/Users/Shared/ornldev/code/ats2/amanzi-tpls/build/0.98.6/openmpi-4.1.5/relwithdebinfo/alquimia/alquimia-1.0.9-source/drivers/DriverOutput.c:90:37: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
DriverOutput* PythonDriverOutput_New()
                                    ^
                                     void
4 errors generated.
```

Looking into this, it seems that this is correct:
https://discourse.llvm.org/t/rfc-enabling-wstrict-prototypes-by-default-in-c/60521

though I don't really know why my compiler is now running with -Werror and I will shortly be fixing that because I'm sure Amanzi has some warnings as well...
