### PR TITLE
undefined behavior in pflotran interface

### DIFF
--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -542,7 +542,7 @@ subroutine ReactionStepOperatorSplit(pft_engine_state, &
 !!$  call RTAuxVarCompute(engine_state%rt_auxvar, &
 !!$                       engine_state%global_auxvar, &
 !!$                       engine_state%reaction, engine_state%option)
-
+  ierror = 0
   call RReact(guess, engine_state%rt_auxvar, engine_state%global_auxvar, &
        engine_state%material_auxvar, num_newton_iterations, &
        reaction, natural_id, engine_state%option, &


### PR DESCRIPTION
PFloTran::RReact() never sets ierror to 0 -- if all goes well, it does not touch ierror.  It only ever sets it to 1 if convergence fails.

As a result, line 553 is undefined behavior.  Under the rare but possible case that ierror is "not initialized" to 1, this takes the wrong branch of the code, but either way undefined behavior is a bad thing.

This bug was found via valgrind...