### PR TITLE
Refactor PFLOTRAN interface

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,7 +37,7 @@ jobs:
         
     - name: pflotran-install
       run: |
-        git clone https://bitbucket.org/pflotran/pflotran --branch v4.0.1 $PFLOTRAN_DIR
+        git clone https://bitbucket.org/pflotran/pflotran --branch master $PFLOTRAN_DIR
         cd $PFLOTRAN_DIR/src/pflotran
         echo "Building libpflotranchem.a"	
         make libpflotranchem.a

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: petsc-install
       run: |
-        git clone https://gitlab.com/petsc/petsc.git --branch v3.18.0 $PETSC_DIR
+        git clone https://gitlab.com/petsc/petsc.git --branch main $PETSC_DIR
         cd $PETSC_DIR
         echo "Alquimia >> Configuring petsc"
         PETSC_ARCH=$PETSC_ARCH ./configure --with-mpi=1 --with-debugging=1 --with-shared-libraries=1 --download-fblaslapack=1 --with-hdf5-dir=/usr/lib/x86_64-linux-gnu/hdf5/openmpi

--- a/alquimia/alquimia_fortran_interface_mod.F90
+++ b/alquimia/alquimia_fortran_interface_mod.F90
@@ -208,8 +208,8 @@ module alquimia_fortran_interface_mod
   
     ! take one (or more?) reaction steps in operator split mode
     interface
-      subroutine ReactionStepOperatorSplit(pft_engine_state, delta_t, props, state, aux_data, status) bind(C)
-        use, intrinsic :: iso_c_binding, only : c_ptr, c_double
+      subroutine ReactionStepOperatorSplit(pft_engine_state, delta_t, props, state, aux_data, natural_id, status) bind(C)
+        use, intrinsic :: iso_c_binding, only : c_ptr, c_double, c_int
         use AlquimiaContainers_module, only : AlquimiaSizes,AlquimiaProblemMetaData,AlquimiaProperties,&
                  AlquimiaState,AlquimiaAuxiliaryData,AlquimiaAuxiliaryOutputData, AlquimiaEngineStatus,&
                  AlquimiaGeochemicalCondition,AlquimiaEngineFunctionality
@@ -219,6 +219,7 @@ module alquimia_fortran_interface_mod
         type(AlquimiaProperties) :: props
         type(AlquimiaState) :: state
         type(AlquimiaAuxiliaryData) :: aux_data
+        integer(c_int),value :: natural_id
         type(AlquimiaEngineStatus) :: status
       end subroutine
     end interface
@@ -310,8 +311,8 @@ module alquimia_fortran_interface_mod
       call engine_ProcessCondition(pft_engine_state,condition,props,state,aux_data,status)
     end subroutine
     
-  subroutine Alquimia_Fortran_ReactionStepOperatorSplit(this,pft_engine_state, delta_t, props, state, aux_data, status)
-    use, intrinsic :: iso_c_binding, only : c_ptr, c_double,c_f_procpointer
+  subroutine Alquimia_Fortran_ReactionStepOperatorSplit(this,pft_engine_state, delta_t, props, state, aux_data, natural_id, status)
+    use, intrinsic :: iso_c_binding, only : c_ptr, c_double,c_f_procpointer,c_int
     use AlquimiaContainers_module, only : AlquimiaSizes,AlquimiaProblemMetaData,AlquimiaProperties,&
              AlquimiaState,AlquimiaAuxiliaryData,AlquimiaAuxiliaryOutputData, AlquimiaEngineStatus,&
              AlquimiaGeochemicalCondition,AlquimiaEngineFunctionality
@@ -322,12 +323,13 @@ module alquimia_fortran_interface_mod
     type(AlquimiaProperties) :: props
     type(AlquimiaState) :: state
     type(AlquimiaAuxiliaryData) :: aux_data
+    integer(c_int),value :: natural_id
     type(AlquimiaEngineStatus) :: status
     
     procedure(ReactionStepOperatorSplit), pointer :: engine_ReactionStepOperatorSplit
     
     call c_f_procpointer(this%c_interface%ReactionStepOperatorSplit,engine_ReactionStepOperatorSplit)
-    call engine_ReactionStepOperatorSplit(pft_engine_state, delta_t, props, state, aux_data, status)
+    call engine_ReactionStepOperatorSplit(pft_engine_state, delta_t, props, state, aux_data, natural_id, status)
   end subroutine
   
   subroutine Alquimia_Fortran_GetAuxiliaryOutput(this,pft_engine_state,props,state,aux_data,aux_out,status)

--- a/alquimia/alquimia_interface.h
+++ b/alquimia/alquimia_interface.h
@@ -93,6 +93,7 @@ extern "C" {
         AlquimiaProperties* props,
         AlquimiaState* state,
         AlquimiaAuxiliaryData* aux_data,
+        int natural_id, 
         AlquimiaEngineStatus* status);
     
     /* Access to user selected geochemical data for output, i.e. pH, 

--- a/alquimia/crunch_alquimia_interface.F90
+++ b/alquimia/crunch_alquimia_interface.F90
@@ -602,10 +602,10 @@ end subroutine ProcessCondition
 
 ! **************************************************************************** !
 subroutine ReactionStepOperatorSplit(cf_engine_state, &
-     delta_t, properties, state, aux_data, status)
+     delta_t, properties, state, aux_data, natural_id, status)
 !  NOTE: Function signature is dictated by the alquimia API.
 
-  use, intrinsic :: iso_c_binding, only : c_ptr, c_double, c_f_pointer
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_double, c_f_pointer, c_int
 
   use c_f_interface_module, only : f_c_string_ptr
 
@@ -630,6 +630,7 @@ subroutine ReactionStepOperatorSplit(cf_engine_state, &
   type (AlquimiaProperties), intent(in) :: properties
   type (AlquimiaState), intent(inout) :: state
   type (AlquimiaAuxiliaryData), intent(inout) :: aux_data
+  integer (c_int), value, intent(in) :: natural_id
   type (AlquimiaEngineStatus), intent(out) :: status
 
   ! local variables

--- a/alquimia/crunch_alquimia_interface.h
+++ b/alquimia/crunch_alquimia_interface.h
@@ -67,6 +67,7 @@ extern "C" {
       AlquimiaProperties* properties,
       AlquimiaState* state,
       AlquimiaAuxiliaryData* aux_data,
+      int natural_id,
       AlquimiaEngineStatus* status);
   void crunch_alquimia_getauxiliaryoutput(
       void* cf_engine_state,

--- a/alquimia/crunch_alquimia_wrappers.F90
+++ b/alquimia/crunch_alquimia_wrappers.F90
@@ -134,6 +134,7 @@ subroutine Crunch_Alquimia_ReactionStepOperatorSplit( &
      properties, &
      state, &
      aux_data, &
+     natural_id, &
      status) bind(C)
 
   use, intrinsic :: iso_c_binding
@@ -149,10 +150,11 @@ subroutine Crunch_Alquimia_ReactionStepOperatorSplit( &
   type (AlquimiaProperties), intent(in) :: properties
   type (AlquimiaState), intent(inout) :: state
   type (AlquimiaAuxiliaryData), intent(inout) :: aux_data
+  integer (c_int), value, intent(in) :: natural_id
   type (AlquimiaEngineStatus), intent(out) :: status
 
   call ReactionStepOperatorSplit(cf_engine_state, delta_t, &
-       properties, state, aux_data, status)
+       properties, state, aux_data, natural_id, status)
 
 end subroutine Crunch_Alquimia_ReactionStepOperatorSplit
 

--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -472,12 +472,12 @@ end subroutine ProcessCondition
 
 ! **************************************************************************** !
 subroutine ReactionStepOperatorSplit(pft_engine_state, &
-     delta_t, properties, state, aux_data, status)
+     delta_t, properties, state, aux_data, natural_id, status)
 !  NOTE: Function signature is dictated by the alquimia API.
 
 #include "petsc/finclude/petscsys.h"
   use petscsys
-  use, intrinsic :: iso_c_binding, only : c_ptr, c_double, c_f_pointer
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_double, c_f_pointer, c_int
 
   use c_f_interface_module, only : f_c_string_ptr
 
@@ -494,6 +494,7 @@ subroutine ReactionStepOperatorSplit(pft_engine_state, &
   type (AlquimiaProperties), intent(in) :: properties
   type (AlquimiaState), intent(inout) :: state
   type (AlquimiaAuxiliaryData), intent(inout) :: aux_data
+  integer (c_int) :: natural_id
   type (AlquimiaEngineStatus), intent(out) :: status
 
   ! local variables
@@ -501,7 +502,6 @@ subroutine ReactionStepOperatorSplit(pft_engine_state, &
   PetscReal :: porosity, volume, vol_frac_prim
   PetscReal, allocatable :: guess(:)
   PetscInt :: i, num_newton_iterations, ierror
-  PetscInt, parameter :: natural_id = -999
   PetscInt, parameter :: phase_index = 1
   logical, parameter :: copy_auxdata = .true.
   class(reaction_rt_type), pointer :: reaction

--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -290,7 +290,7 @@ subroutine Shutdown(pft_engine_state, status)
 
   ! pflotran
   use Option_module, only : OptionDestroy
-  use Driver_module, only : DriverDestroy
+  use Driver_class, only : DriverDestroy
   use Reaction_aux_module, only : ReactionDestroy
   use Transport_Constraint_Base_module, only : tran_constraint_coupler_base_type
   use Transport_Constraint_module, only : TranConstraintCouplerDestroy, &
@@ -961,7 +961,7 @@ subroutine SetupPFLOTRANOptions(input_filename, option)
   use c_f_interface_module, only : c_f_string_chars
 
   use Option_module, only : option_type
-  use Driver_module, only : DriverCreate
+  use Driver_class, only : DriverCreate
   use Communicator_Aux_module, only : CommCreate
   use PFLOTRAN_Constants_module
   use petscsys

--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -148,6 +148,7 @@ subroutine Setup(input_filename, hands_off, pft_engine_state, sizes, &
   use AlquimiaContainers_module
 
   ! pflotran
+  use Logging_module
   use Reaction_Aux_module, only : reaction_rt_type
   use Reactive_Transport_Aux_module, only : reactive_transport_auxvar_type, &
        RTAuxVarInit
@@ -191,6 +192,7 @@ subroutine Setup(input_filename, hands_off, pft_engine_state, sizes, &
   ! setup pflotran's option object, including mpi
   option => OptionCreate()
   call SetupPFLOTRANOptions(input_filename, option)
+  call LoggingCreate()
 
   write (*, '(a, a)') "  Reading : ", trim(option%input_filename)
   input => InputCreate(IN_UNIT, option%input_filename, option)

--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -64,7 +64,7 @@ module PFLOTRANAlquimiaInterface_module
   use Reaction_Base_module, only : reaction_base_type
   use Reactive_Transport_Aux_module, only : reactive_transport_auxvar_type
   use Global_Aux_module, only : global_auxvar_type
-  use Material_Aux_class, only : material_auxvar_type
+  use Material_Aux_module, only : material_auxvar_type
   use Transport_Constraint_module, only : tran_constraint_list_type
   use Transport_Constraint_RT_module, only : tran_constraint_coupler_rt_type
 
@@ -119,7 +119,7 @@ module PFLOTRANAlquimiaInterface_module
      class(reaction_rt_type), pointer :: reaction
      type(reactive_transport_auxvar_type), pointer :: rt_auxvar
      type(global_auxvar_type), pointer :: global_auxvar
-     class(material_auxvar_type), pointer :: material_auxvar
+     type(material_auxvar_type), pointer :: material_auxvar
      type(tran_constraint_list_type), pointer :: transport_constraints
      class(tran_constraint_coupler_rt_type), pointer :: constraint_coupler 
   end type PFLOTRANEngineState
@@ -152,7 +152,7 @@ subroutine Setup(input_filename, hands_off, pft_engine_state, sizes, &
   use Reactive_Transport_Aux_module, only : reactive_transport_auxvar_type, &
        RTAuxVarInit
   use Global_Aux_module, only : global_auxvar_type, GlobalAuxVarInit
-  use Material_Aux_class, only : material_auxvar_type, MaterialAuxVarInit
+  use Material_Aux_module, only : material_auxvar_type, MaterialAuxVarInit
   use Option_module, only : option_type, OptionCreate
   use Input_Aux_module, only : input_type, InputCreate, InputDestroy
   use Transport_Constraint_module, only : tran_constraint_list_type
@@ -178,7 +178,7 @@ subroutine Setup(input_filename, hands_off, pft_engine_state, sizes, &
   type(option_type), pointer :: option
   type(input_type), pointer :: input
   type(global_auxvar_type), pointer :: global_auxvar
-  class(material_auxvar_type), pointer :: material_auxvar
+  type(material_auxvar_type), pointer :: material_auxvar
   type(reactive_transport_auxvar_type), pointer :: rt_auxvar
   type(tran_constraint_list_type), pointer :: transport_constraints
   class(tran_constraint_coupler_rt_type), pointer :: constraint_coupler 
@@ -546,7 +546,7 @@ subroutine ReactionStepOperatorSplit(pft_engine_state, &
   call RReact(guess, engine_state%rt_auxvar, engine_state%global_auxvar, &
        engine_state%material_auxvar, num_newton_iterations, &
        reaction, natural_id, engine_state%option, &
-       PETSC_FALSE, PETSC_FALSE, ierror)
+       PETSC_TRUE, PETSC_FALSE, ierror)
   deallocate(guess)
 
 
@@ -1318,7 +1318,7 @@ subroutine ProcessPFLOTRANConstraint(option, reaction, global_auxvar, &
   use Reaction_Aux_module, only : reaction_rt_type
   use Reactive_Transport_Aux_module, only : reactive_transport_auxvar_type
   use Global_Aux_module, only : global_auxvar_type
-  use Material_Aux_class, only : material_auxvar_type
+  use Material_Aux_module, only : material_auxvar_type
   use Transport_Constraint_RT_module, only : tran_constraint_rt_type, &
                                              tran_constraint_coupler_rt_type
   use Option_module, only : option_type, PrintMsg, PrintErrMsg
@@ -1329,7 +1329,7 @@ subroutine ProcessPFLOTRANConstraint(option, reaction, global_auxvar, &
   type(option_type), pointer, intent(in) :: option
   class(reaction_rt_type), pointer, intent(inout) :: reaction
   type(global_auxvar_type), pointer, intent(inout) :: global_auxvar
-  class(material_auxvar_type), pointer, intent(inout) :: material_auxvar
+  type(material_auxvar_type), pointer, intent(inout) :: material_auxvar
   type(reactive_transport_auxvar_type), pointer, intent(inout) :: rt_auxvar
   class(tran_constraint_coupler_rt_type), pointer, intent(inout) :: constraint_coupler 
 
@@ -1579,7 +1579,7 @@ subroutine CopyAlquimiaToAuxVars(copy_auxdata, hands_off, &
   use Reaction_aux_module, only : reaction_rt_type
   use Reactive_Transport_Aux_module, only : reactive_transport_auxvar_type
   use Global_Aux_module, only : global_auxvar_type
-  use Material_Aux_class, only : material_auxvar_type
+  use Material_Aux_module, only : material_auxvar_type
 
   implicit none
 
@@ -1591,7 +1591,7 @@ subroutine CopyAlquimiaToAuxVars(copy_auxdata, hands_off, &
   type (AlquimiaProperties), intent(in) :: prop
   class(reaction_rt_type), pointer, intent(inout) :: reaction
   type(global_auxvar_type), pointer, intent(inout) :: global_auxvar
-  class(material_auxvar_type), pointer, intent(inout) :: material_auxvar
+  type(material_auxvar_type), pointer, intent(inout) :: material_auxvar
   type(reactive_transport_auxvar_type), pointer, intent(inout) :: rt_auxvar
 
   ! local variables

--- a/alquimia/pflotran_alquimia_interface.h
+++ b/alquimia/pflotran_alquimia_interface.h
@@ -67,6 +67,7 @@ extern "C" {
       AlquimiaProperties* material_properties,
       AlquimiaState* state,
       AlquimiaAuxiliaryData* aux_data,
+      int natural_id,
       AlquimiaEngineStatus* status);
   void pflotran_alquimia_getauxiliaryoutput(
       void* pft_engine_state,

--- a/alquimia/pflotran_alquimia_wrappers.F90
+++ b/alquimia/pflotran_alquimia_wrappers.F90
@@ -133,6 +133,7 @@ subroutine PFloTran_Alquimia_ReactionStepOperatorSplit( &
      properties, &
      state, &
      aux_data, &
+     natural_id, &
      status) bind(C)
 
   use, intrinsic :: iso_c_binding
@@ -148,10 +149,11 @@ subroutine PFloTran_Alquimia_ReactionStepOperatorSplit( &
   type (AlquimiaProperties), intent(in) :: properties
   type (AlquimiaState), intent(inout) :: state
   type (AlquimiaAuxiliaryData), intent(inout) :: aux_data
+  integer(c_int), value, intent(in) :: natural_id
   type (AlquimiaEngineStatus), intent(out) :: status
 
   call ReactionStepOperatorSplit(pft_engine_state, delta_t, &
-       properties, state, aux_data, status)
+       properties, state, aux_data, natural_id, status)
 
 end subroutine PFloTran_Alquimia_ReactionStepOperatorSplit
 

--- a/drivers/BatchChemDriver.c
+++ b/drivers/BatchChemDriver.c
@@ -555,6 +555,7 @@ int BatchChemDriver_Run(BatchChemDriver* driver)
     printf("BatchChemDriver: running %s\n", driver->description);
 
   double dt = driver->dt;
+  int natural_id;
 
   // Initialize the chemistry state and set up the solution vector.
   int status = BatchChemDriver_Initialize(driver);
@@ -569,10 +570,12 @@ int BatchChemDriver_Run(BatchChemDriver* driver)
       printf("BatchChemDriver: step %d (t = %g, dt = %g)\n", driver->step, driver->time, dt);
 
     // Do the chemistry step.
+    natural_id = -999;
     driver->chem.ReactionStepOperatorSplit(&driver->chem_engine,
                                            dt, &driver->chem_properties,
                                            &driver->chem_state,
                                            &driver->chem_aux_data,
+                                           natural_id,
                                            &driver->chem_status);
     if (driver->chem_status.error != 0)
     {

--- a/drivers/TransportDriver.c
+++ b/drivers/TransportDriver.c
@@ -669,6 +669,7 @@ static int Run_OperatorSplit(TransportDriver* driver)
   double dx = (driver->x_max - driver->x_min) / driver->num_cells;
   double dt = Min(driver->dt, driver->cfl * dx / driver->vx);
   int num_primary = driver->chem_sizes.num_primary;
+  int natural_id;
 
   // Initialize the chemistry state in each cell, and set up the solution vector.
   int status = TransportDriver_Initialize(driver);
@@ -710,10 +711,12 @@ static int Run_OperatorSplit(TransportDriver* driver)
       }
 
       // Do the chemistry step, using the advected state as input.
+      natural_id = -999;
       driver->chem.ReactionStepOperatorSplit(&driver->chem_engine,
                                              dt, &driver->chem_properties[i],
                                              &driver->advected_chem_state,
                                              &driver->advected_chem_aux_data,
+                                             natural_id,
                                              &driver->chem_status);
       if (driver->chem_status.error != 0)
       {


### PR DESCRIPTION
This PR refactors the following within the PFLOTRAN interface

- Several derived types and classes have been revised, renamed, reclassified (class -> type).
- The natural ID of the grid cell is now passed to ReactionStepOperatorSpit routine for debugging purposes. This is critical for large problems within ATS where there is little to no information regarding the location of cells that fail to converge for chemistry.