### PR TITLE
Fixes negative file unit number

### DIFF
--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -1004,6 +1004,7 @@ subroutine SetupPFLOTRANOptions(input_filename, option)
   ! output file
   !
   option%fid_out = DRIVER_OUT_UNIT
+  option%driver%fid_out = DRIVER_OUT_UNIT
 
   filename_out = trim(option%global_prefix) // trim(option%group_prefix) // &
                  '.out.alquimia'


### PR DESCRIPTION
Amaniz test revealed that a file unit number could be negative. This fix initializes the unit number to a positive value.