### PR TITLE
Improve functionality of the mineral surface area update

### DIFF
--- a/alquimia/pflotran_alquimia_interface.F90
+++ b/alquimia/pflotran_alquimia_interface.F90
@@ -1654,12 +1654,14 @@ subroutine CopyAlquimiaToAuxVars(copy_auxdata, hands_off, &
        (/reaction%mineral%nkinmnrl/))
   do i = 1, reaction%mineral%nkinmnrl
      rt_auxvar%mnrl_volfrac(i) = data(i)
+     rt_auxvar%mnrl_volfrac0(i) = data(i)
   end do
 
   call c_f_pointer(state%mineral_specific_surface_area%data, data, &
        (/reaction%mineral%nkinmnrl/))
   do i = 1, reaction%mineral%nkinmnrl
      rt_auxvar%mnrl_area(i) = data(i)
+     rt_auxvar%mnrl_area0(i) = data(i)
   end do
 
   !


### PR DESCRIPTION
Adds an initial surface area and volume fraction defined at the beginning of each timestep to reference during the update to surface area based on mineral dissolution/precipitation. Previously this absence caused issues if mineral surface areas of volume fractions were different in different regions of the simulation because Alquimia only retained the initial properties for one region.